### PR TITLE
Mark Twig function's output as safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,6 @@ $this->get('php_to_js')->put([
 Then in Twig template (probably that will be useful to move it to layout):
 ```
 <script>
-    {{ initPhpVars() | raw }}
+    {{ initPhpVars() }}
 </script>
 ```

--- a/Twig/JavaScriptExtension.php
+++ b/Twig/JavaScriptExtension.php
@@ -23,7 +23,7 @@ class JavaScriptExtension extends \Twig_Extension
     public function getFunctions()
     {
         return [
-            new \Twig_SimpleFunction('initPhpVars', [$this, 'initPhpVars']),
+            new \Twig_SimpleFunction('initPhpVars', [$this, 'initPhpVars'], ['is_safe' => ['html']]),
         ];
     }
 


### PR DESCRIPTION
This allows avoiding `raw` filter usage.
See automatic escaping http://twig.sensiolabs.org/doc/advanced.html#automatic-escaping
