### PR TITLE
Add "type": "symfony-bundle" in composer file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "name": "hospect/php-vars-to-js-bundle",
+    "type": "symfony-bundle",
     "description": "Transformation of PHP vars to JS for Symfony2 with Twig",
     "license": "MIT",
     "require": {


### PR DESCRIPTION
This allows Symfony Flex to enable the bundle on bundles.php file